### PR TITLE
Add Due Date Webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Env-specific config
+.env

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -15,4 +15,27 @@ export class AppController {
     const result = await this.appService.parseTask(body.payload);
     return JSON.stringify(result);
   }
+  @Post('/task-date-changed')
+  async whenTaskDateChanged(@Body() body: TaskResponse): Promise<boolean> {
+    const task = body.payload;
+
+    if (task.parent) {
+      // Fetch the parent task, and check its subtasks.
+      const parentId = task.parent;
+      const { data: parent } = await this.appService.getTask(parentId, true);
+
+      // Get the latest subtask due date. This is the date we'll set the
+      // parent to, if the parent task isn't already set far enough in the future.
+      const latestDate = (parent.subtasks || []).reduce((acc, subtask) => {
+        return subtask.due_date && subtask.due_date > acc ? subtask.due_date : acc;
+      }, parent.due_date);
+
+      // If the latest due date is different than the current parent date,
+      // update the parent to the new due date.
+      if (latestDate !== parent.due_date) {
+        this.appService.updateTask(parentId, { due_date: latestDate });
+      }
+    }
+    return true;
+  }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,5 +1,5 @@
 import { HttpService, Injectable } from '@nestjs/common';
-import { Task } from './interfaces/Task';
+import { Task, PartialTask } from './interfaces/Task';
 import { AxiosResponse } from 'axios';
 import { ConfigService } from '@nestjs/config';
 
@@ -28,9 +28,11 @@ export class AppService {
       return createdTask.data;
     }
   }
-  async getTask(taskId: string) {
+  async getTask(taskId: string, includeSubtasks?: boolean) {
+    const queryParams = includeSubtasks ? '?include_subtasks=true' : '';
+
     return this.httpService
-      .get(`${this.clickUpBaseUrl}/task/${taskId}/`, {
+      .get(`${this.clickUpBaseUrl}/task/${taskId}/${queryParams}`, {
         headers: {
           Authorization: `${this.apitoken}`,
         },
@@ -63,6 +65,19 @@ export class AppService {
     return this.httpService
       .post(
         `${this.clickUpBaseUrl}/list/${this.correspondanceListId}/task/`,
+        task,
+        {
+          headers: {
+            Authorization: `${this.apitoken}`,
+          },
+        },
+      )
+      .toPromise();
+  }
+  updateTask(taskId: string, task: PartialTask): Promise<AxiosResponse<Task>> {
+    return this.httpService
+      .put(
+        `${this.clickUpBaseUrl}/task/${taskId}`,
         task,
         {
           headers: {

--- a/src/interfaces/Task.ts
+++ b/src/interfaces/Task.ts
@@ -45,6 +45,24 @@ export interface Task {
   folder: ProjectOrFolder;
   space: Space;
 }
+// PartialTask is the interface we send when updating tasks. Although
+// it is implemented as a PUT in ClickUp's API, we only send partial values
+// (the properties we want to update). To remove or unset a field, explicitly
+// pass it in here as `null`.
+export interface PartialTask {
+  name?: string;
+  text_content?: null;
+  description?: null;
+  status?: Status;
+  orderindex?: string;
+  archived?: boolean;
+  tags?: null[] | null;
+  priority?: null;
+  due_date?: null;
+  start_date?: null;
+  points?: null;
+  time_estimate?: null;
+}
 export interface Status {
   id: string;
   status: string;


### PR DESCRIPTION
This PR adds a new webhook, `/task-date-changed`, which allows subtasks to update their parent's due date.

<iframe src="https://share.getcloudapp.com/z8uOErgO?embed=true" width="575" height="400" frameborder="0" allowtransparency="true" allowfullscreen="allowfullscreen" data-frame-src="https://share.getcloudapp.com/z8uOErgO?embed=true" style="border: none;"></iframe>

When you change a subtask's due date, it will fetch the parent's data and check all of the other subtasks. It will then set the parent's due date to the _latest_ date of any subtask (or the parent's date, if it's already after all of the subtasks). This action cascades up through parent tasks, so they will always end up with due dates after their subtasks.